### PR TITLE
SC-8772 - mongodb connection string 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Release 1.2.3
 
+## Bugfix
+
 - SC-8772 - update extend of mongodb connection
 
 # Release 1.2.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Release 1.2.3
+
+- SC-8772 - update extend of mongodb connection
+
 # Release 1.2.2
 
 ## Features

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "notification-service",
-	"version": "1.2.2",
+	"version": "1.2.3",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "notification-service",
-	"version": "1.2.2",
+	"version": "1.2.3",
 	"description": "A notification service for mails and push notifications build with Typescript on top of Node and Express.js.",
 	"homepage": "https://github.com/schul-cloud/node-notification-service",
 	"bugs": {

--- a/src/app.ts
+++ b/src/app.ts
@@ -66,7 +66,7 @@ app.use((err: HttpException, req: Request, res: Response, next: NextFunction) =>
 const db = mongoose.connection;
 // tslint:disable-next-line: no-console
 db.on('error', console.error.bind(logger, 'connection error:'));
-const mongoHost = `mongodb://${process.env.MONGO_HOST || 'localhost'}/notification-service`;
+const mongoHost = `mongodb://${process.env.MONGO_HOST || 'localhost/notification-service'}`;
 logger.info('mongo host', { mongoHost });
 mongoose.connect(mongoHost);
 


### PR DESCRIPTION
# Description

the connection string for mongodb where extend default by /notification-service who trubel other connection strings.

## Links to Tickets or other pull requests

https://ticketsystem.hpi-schul-cloud.org/browse/SC-8772

## Changes

SC-8772 - Connection string update 

## Datasecurity <sub><sup>details [on Confluence](https://docs.schul-cloud.org/x/2S3GBg)</sup></sub>

Connection string update

## Deployment


## New Repos, NPM pakages or vendor scripts


## Screenshots of UI changes


## Approval for review

- [ ] All points were discussed with the ticket creator, support-team or product owner. The code upholds all quality guidelines from the PR-template.

> Notice: Please remove the WIP label if the PR is ready to review, otherwise nobody will review it.

### Link to Definiton of Done

More and detailed information on the _definition of done_ can be found [on Confluence](https://docs.schul-cloud.org/pages/viewpage.action?pageId=92831762)
